### PR TITLE
Starting Cronjob 1 Minute Past Rounded Hour

### DIFF
--- a/helm-chart-sources/k8s-metrics-collector/values.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/values.yaml
@@ -56,7 +56,7 @@ environment:
   #  KUBELET_JOB_NAME: 'kubelet'
 
   # When workload of type Deployment is set (non-default), uncomment this (and leave the value as it is).
-  # CRON_SCHEDULE: : "0 * * * *"
+  # CRON_SCHEDULE: : "1 * * * *"
 
   # The following values are for internal use and should not be modified.
   S3_BUCKET: 'prod-prometheus-agent'
@@ -89,7 +89,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 CronJob:
-  schedule: "0 * * * *"
+  schedule: "1 * * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 15
   failedJobsHistoryLimit: 3

--- a/helm-chart-sources/k8s-metrics-collector/values.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/values.yaml
@@ -58,11 +58,6 @@ environment:
   # When workload of type Deployment is set (non-default), uncomment this (and leave the value as it is).
   # CRON_SCHEDULE: : "1 * * * *"
 
-  # The following values are for internal use and should not be modified.
-  S3_BUCKET: 'prod-prometheus-agent'
-  MONITORING: 'none'
-  LOG_TO_CLOUD_WATCH: 'true'
-  
 
 environmentSecrets:
   # Access key required for uploading collected metrics to Anodot (should be provided to you by Anodot)


### PR DESCRIPTION
* Changed the agent to start after one minute (to minimize samples loss when querying for the last rounded hour due to ingestion time)
* Removed internal settings from the values.yaml file