### PR TITLE
Make k8s-metrics-collector chart compatible with `readOnlyRootFilesystem: true`

### DIFF
--- a/helm-chart-sources/k8s-metrics-collector/Chart.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.3.20
 description: A Helm chart for Kubernetes
 name: k8s-metrics-collector
 type: application
-version: 0.1.21
+version: 0.1.22
 dependencies:
 - condition: kubePrometheusStack.enabled
   name: kube-prometheus-stack

--- a/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
@@ -45,6 +45,8 @@ spec:
                   value: {{ .Values.workload }}
                 - name: APP_VERSION
                   value:  {{ .Values.image.tag | default .Chart.AppVersion }}
+                - name: APP_DATA_DIR
+                  value: /tmp/data
                 {{- if .Values.kubePrometheusStack.enabled }}
                 - name: PROMETHEUS_URL
                   value: http://{{ index .Values "kube-prometheus-stack" "fullnameOverride" }}-prometheus:9090
@@ -97,12 +99,13 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
-                - mountPath: /usr/src/app/src/agent/data
+                - mountPath: /tmp
                   name: appdata
-                  subPath: data
+                  subPath: tmp
                 - mountPath: /var/log
                   name: appdata
                   subPath: log
+              command: ["/bin/sh", "-c", "cp -r /usr/src/app/src/agent/data /tmp && /usr/src/app/entry.sh"]
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
           volumes:

--- a/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
@@ -99,7 +99,10 @@ spec:
                 {{- end }}
                 - mountPath: /usr/src/app/src/agent/data
                   name: appdata
-
+                  subPath: data
+                - mountPath: /var/log
+                  name: appdata
+                  subPath: log
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
           volumes:

--- a/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/cronjob.yaml
@@ -97,6 +97,8 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+                - mountPath: /usr/src/app/src/agent/data
+                  name: appdata
 
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
@@ -108,6 +110,8 @@ spec:
                 name: {{ include "k8s-metrics-collector.fullname" . }}
           {{- end }}
           {{- end }}
+            - emptyDir: {}
+              name: appdata
 
           {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: {{ .Values.workload }}
             - name: APP_VERSION
               value:  {{ .Values.image.tag | default .Chart.AppVersion }}
+            - name: APP_DATA_DIR
+              value: /tmp/data
             {{- if .Values.kubePrometheusStack.enabled }}
             - name: PROMETHEUS_URL
               value: http://{{ index .Values "kube-prometheus-stack" "fullnameOverride" }}-prometheus:9090
@@ -95,12 +97,13 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            - mountPath: /usr/src/app/src/agent/data
+            - mountPath: /tmp
               name: appdata
-              subPath: data
+              subPath: tmp
             - mountPath: /var/log
               name: appdata
               subPath: log
+          command: ["/bin/sh", "-c", "cp -r /usr/src/app/src/agent/data /tmp && /usr/src/app/entry.sh"]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             {{- end }}
             - mountPath: /usr/src/app/src/agent/data
               name: appdata
+              subPath: data
+            - mountPath: /var/log
+              name: appdata
+              subPath: log
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            - mountPath: /usr/src/app/src/agent/data
+              name: appdata
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -105,6 +107,8 @@ spec:
             name: {{ include "k8s-metrics-collector.fullname" . }}
       {{- end }}
       {{- end }}
+        - emptyDir: {}
+          name: appdata
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart-sources/k8s-metrics-collector/values.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/values.yaml
@@ -179,6 +179,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext: {}
+  # allowPrivilegeEscalation: false
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
We have security requirements on our Kubernetes cluster, one of which is that all pods have a readOnlyRootFilesystem in their security policy (and the commented example in the chart already has).

However there are a number of bits of the app which seem to write to the root filesystem; the logging (to /var/log/agent.log) and the app data directory which also contains read only data.

The approach I've taken is pretty hacky but does work. It might be better to alter the app itself to use /tmp for writing any data and stop logging to the filesystem as well as stdout.