### PR TITLE
Allow adding sidecars to Deployment

### DIFF
--- a/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/templates/deployment.yaml
@@ -97,6 +97,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
       {{- if .Values.configmap.enabled  }}
       {{- if or .Values.configmap.files .Values.configmap.binaryFiles }}

--- a/helm-chart-sources/k8s-metrics-collector/values.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/values.yaml
@@ -199,3 +199,22 @@ prometheusrule:
 
 configmap:
   enabled: false
+
+
+sidecars: []
+  # # Replace ${awsRegion} with your region.
+  # - name: aws-sigv4-proxy
+  #   image: public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0
+  #   args:
+  #     - --name
+  #     - aps
+  #     - --region
+  #     - ${awsRegion}
+  #     - --host
+  #     - aps-workspaces.${awsRegion}.amazonaws.com
+  #   env:
+  #     - name: AWS_REGION
+  #       value: ${awsRegion}
+  #   ports:
+  #     - name: aws-sigv4-proxy
+  #       containerPort: 8080


### PR DESCRIPTION
This PR adds support for sidecar containers to the "Deployment" type, e.g. to add a SigV4 proxy to communicate with AWS Managed Prometheus.