### PR TITLE
"Anodot" to "Umbrella

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This repository contains the following helm charts:
 
 * [anodot-cost-k8s-cw-agent](helm-chart-sources/anodot-cost-k8s-cw-agent/README.md) (a.k.a. AWS CloudWatch-Agent)
-* [k8s-metrics-collector](helm-chart-sources/k8s-metrics-collector/README.md) (a.k.a. Anodot Prometheus-Agent )
+* [k8s-metrics-collector](helm-chart-sources/k8s-metrics-collector/README.md) (a.k.a. Umbrella Prometheus-Agent )

--- a/helm-chart-sources/anodot-cost-k8s-cw-agent/README.md
+++ b/helm-chart-sources/anodot-cost-k8s-cw-agent/README.md
@@ -3,16 +3,16 @@
 This Helm chart is for the installation of AWS's CloudWatch-Agent for Kubernetes.
 
 This is an official AWS release for a K8S agent deployed as DaemonSet that collects metrics from the cluster, which is
-used by Anodot-Costs to analyze cluster usage and allocate cloud costs to its components.
+used by Umbrella to analyze cluster usage and allocate cloud costs to its components.
 
-This chart includes configuration settings that disables extended metrics (enabled by default in AWS's official
-distribution) which are very costly and not required for Anodot's solution for usage and costs analysis. 
+This chart includes configuration settings that disable extended metrics (enabled by default in AWS's official
+distribution) which are very costly and not required for Umbrella's solution for usage and costs analysis. 
 
 # Installation
 
-## Add or update the Anodot repository 
+## Add or update the Umbrella repository 
 
-Add the Anodot repository by running:
+Add the Umbrella repository by running:
 ```shell
 helm repo add anodot https://pileus-cloud.github.io/charts
 ```

--- a/helm-chart-sources/k8s-metrics-collector/README.md
+++ b/helm-chart-sources/k8s-metrics-collector/README.md
@@ -1,11 +1,11 @@
-# Prometheus-Agent for Anodot-Cost
+# Prometheus-Agent for Umbrella-Cost
 
 ## Introduction
 
-This Helm chart is for the installation of Anodot's Prometheus-Agent for Kubernetes.
+This Helm chart is for the installation of Umbrella's Prometheus-Agent for Kubernetes.
 
-This agent is deployed as ChronJob and collects metrics of the cluster from Prometheus, and sends them to Anodot, where
-it is then being analyzed for usage and cloud costs allocation to the cluster's components. 
+This agent is deployed as ChronJob and collects metrics of the cluster from Prometheus, and sends them to Umbrella, 
+where it is then being analyzed for usage and cloud costs allocation to the cluster's components. 
 
 
 ## Table of contents
@@ -23,9 +23,9 @@ The agent has to be installed **per cluster**.  In case metrics from multiple cl
 repository, there should be an agent instance for each cluster, where each agent is [configured](values.yaml) to match metrics
 from a single cluster. 
 
-The followings are required before installing Prometheus-Agent for Anodot-Cost:
+The followings are required before installing Prometheus-Agent for Umbrella:
 - `Helm 3`
-- Anodot Access Key for uploading collected metrics (should be provided to you by Anodot)
+- Umbrella Access Key for uploading collected metrics (should be provided to you by Umbrella)
 - Prometheus or a compatible service with accessible Prometheus-query API endpoint
   - The agent can either integrate with your existing Prometheus server, or be installed with a compatible lightweight
     Prometheus stack provided by this chart.
@@ -83,7 +83,10 @@ $ helm upgrade <PROMETHEUS RELEASE> <OTHER OPTIONAL ARGS> --set kube-state-metri
 The agent can be installed solitarily as a release that integrates with your existing Prometheus server (the default),
 or as a standalone release that also includes a compatible lightweight Prometheus stack.
 
-1. Add anodot-cost Helm repository:
+Note: Umbrella recommends that you integrate with a Prometheus solution maintained by your end if possible. It is also
+strongly discouraged to include the optional Prometheus stack if you already have a Prometheus solution in your cluster.
+
+1. Add the Umbrella Helm repository:
    ```bash
    $ helm repo add anodot-cost https://pileus-cloud.github.io/charts
    ```
@@ -94,7 +97,7 @@ or as a standalone release that also includes a compatible lightweight Prometheu
 
 2. Set the required parameters in the [values.yaml](values.yaml) file and save a copy locally (preferably containing 
    just the modified values). Make sure to replace all the relevant values according to the comments for each value,
-   including the Anodot access key.
+   including the Umbrella access key.
    * Alternatively, you can set any value as a set argument in the `helm upgrade` command. You can also use a method for
      [storing secrets safely](storing-secrets.md) such as [external-secrets](https://external-secrets.io/).
     

--- a/helm-chart-sources/k8s-metrics-collector/storing-secrets.md
+++ b/helm-chart-sources/k8s-metrics-collector/storing-secrets.md
@@ -12,7 +12,7 @@ Preferred option is to use helm chart: https://external-secrets.io/v0.8.1/introd
 
 2. Create secret in cloud provider vault
 
-Create secret in cloud provider (e.g. AWS ParameterStore) with preferred name, e.g. `/prod/anodot/secrets`. The same name must be used in ExternalSecret manifest `kind: ExternalSecret` `remoteRef.key`. Secret values must be in JSON format, e.g `{"AWS_ACCESS_KEY_ID": "MySecretKeyId", "AWS_SECRET_ACCESS_KEY": "MySecretAccessKey"}`. Single cloud provider secret can contain many key,value pairs.
+Create secret in cloud provider (e.g. AWS ParameterStore) with preferred name, e.g. `/prod/umbrella/secrets`. The same name must be used in ExternalSecret manifest `kind: ExternalSecret` `remoteRef.key`. Secret values must be in JSON format, e.g `{"AWS_ACCESS_KEY_ID": "MySecretKeyId", "AWS_SECRET_ACCESS_KEY": "MySecretAccessKey"}`. Single cloud provider secret can contain many key,value pairs.
 
 3. Ensure Kubernetes cluster has permissions to get secrets from cloud provider vault.
 
@@ -20,7 +20,7 @@ Create secret in cloud provider (e.g. AWS ParameterStore) with preferred name, e
 
 SecretStore is used to connect to cloud provider secrets, e.g. https://external-secrets.io/v0.8.1/provider/aws-secrets-manager/
 
-ExternalSecret is used to generate Kuberentes Secret fetched from cloud provider secret. Generated Kuberentes Secret will be used further by k8s-metrics-collector after upgrade/installation.
+ExternalSecret is used to generate Kubernetes Secret fetched from cloud provider secret. Generated Kubernetes Secret will be used further by k8s-metrics-collector after upgrade/installation.
 
 External-secrets example for AWS ParameterStore integration:
 
@@ -29,7 +29,7 @@ cat <<EOF | kubectl apply -f -
  apiVersion: external-secrets.io/v1beta1
  kind: SecretStore
  metadata:
-   name: anodot
+   name: umbrella
    namespace: monitoring
  spec:
    provider:
@@ -44,29 +44,29 @@ cat <<EOF | kubectl apply -f -
  apiVersion: external-secrets.io/v1beta1
  kind: ExternalSecret
  metadata:
-   name: anodot
+   name: umbrella
    namespace: monitoring
  spec:
    refreshInterval: 1h                          # rate secrets sync interval
    secretStoreRef:
      kind: SecretStore
-     name: anodot                               # name of SecretStore
+     name: umbrella                             # name of SecretStore
    target:
     # Kubernetes Secret will be generated with target name
     # Consider the same name is used in chart k8s-metrics-collector in environmentExternalSecrets.name 
-     name: anodot-cost-secrets                  # Kubernetes Secret name to be created
+     name: umbrella-cost-secrets                # Kubernetes Secret name to be created
      creationPolicy: Owner
    data:
    - secretKey: AWS_ACCESS_KEY_ID               # Kubernetes Secret key name 
      remoteRef:
-       key: /prod/anodot/secrets                # secret name created in cloud vault
+       key: /prod/umbrella/secrets              # secret name created in cloud vault
        # secrets must be stored in JSON format in cloud provider vault
        # for this secret example  {"AWS_ACCESS_KEY_ID": "MySecretKeyId", "AWS_SECRET_ACCESS_KEY": "MySecretAccessKey"} 
        # value MySecretKeyId will be fetched based on key AWS_ACCESS_KEY_ID and added to Kubernetes Secret
        property: AWS_ACCESS_KEY_ID              
    - secretKey: AWS_SECRET_ACCESS_KEY
      remoteRef:
-       key: /prod/anodot/secrets
+       key: /prod/umbrella/secrets
        property: AWS_SECRET_ACCESS_KEY
 EOF
 ```

--- a/helm-chart-sources/k8s-metrics-collector/values.yaml
+++ b/helm-chart-sources/k8s-metrics-collector/values.yaml
@@ -13,7 +13,7 @@ environment:
   # The name of the K8S cluster, which should match its name in your cloud environment
   CLUSTER_NAME: '<INSERT CLUSTER NAME HERE>'
 
-  # Root account ID: In AWS that's ID of the payer account. For Azure it's the name of the account in Anodot-Costs>'
+  # Root account ID: In AWS that's ID of the payer account. For Azure it's the name of the account in Umbrella-Cost>'
   ACCOUNT_ID: '<INSERT ROOT ACCOUNT ID HERE>'
 
   # Cluster owner account ID: In AWS that's the linked account ID owning the cluster. In Azure that's the subscription ID.
@@ -72,9 +72,9 @@ environment:
 
 
 environmentSecrets:
-  # Access key required for uploading collected metrics to Anodot (should be provided to you by Anodot)
-  AWS_ACCESS_KEY_ID: '<INSERT ANODOT ACCESS KEY>'
-  AWS_SECRET_ACCESS_KEY: '<INSERT ANODOT SECRET ACCESS KEY>'
+  # Access key required for uploading collected metrics to Umbrella (should be provided to you by Umbrella)
+  AWS_ACCESS_KEY_ID: '<INSERT UMBRELLA ACCESS KEY>'
+  AWS_SECRET_ACCESS_KEY: '<INSERT UMBRELLA SECRET ACCESS KEY>'
 
 kubePrometheusStack:
   # Enable prometheus deployment
@@ -163,7 +163,7 @@ serviceAccount:
 environmentExternalSecrets:
   enabled: false
   ## Provide secret name, it must be the same as defined in kind:ExternalSecret target.name, more details in README.md
-  name: anodot-cost-secrets
+  name: umbrella-cost-secrets
 
 resources: {}
   # The following settings were tested on ~100000 metrics. The agent might require a larger amount of resources in case


### PR DESCRIPTION
* Renamed "Anodot" to "Umbrella" in the documentation files (chart/release etc. were remained as before, also when referred in documentation).
* Recommendation to use existent Prometheus and not combine existent with the optional stack in the chart.